### PR TITLE
Initialize a GitHub CI action - fixes #53

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,30 @@
+# Continuous Integration for Gradle
+# Runs `gradle build` (which also executes tests) and then builds and uploads
+# the :repl:shadowJar artifact. Gradle is also configured to generate
+# Build Scan links (see settings.gradle.kts) which is surfaced with the build.
+#
+# References:
+# * https://docs.gradle.org/current/userguide/github-actions.html
+# * https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+# * https://github.com/gradle/gradle-build-action
+
+name: Gradle
+
+on: [push, pull_request]
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Build REPL jar
+      run: ./gradlew :repl:shadowJar
+    - name: Upload REPL jar
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'repl-all.jar'
+        path: 'repl/build/libs/repl-all.jar'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,18 @@
+// Enable Build Scans
+// https://docs.gradle.org/current/userguide/github-actions.html#enable_build_scan_publishing
+plugins {
+    id("com.gradle.enterprise") version("3.9")
+}
+gradleEnterprise {
+    if (System.getenv("CI") != null) {
+        buildScan {
+            publishAlways()
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+        }
+    }
+}
+
 rootProject.name = "solarnet"
 
 include("pets", "engine", "repl", "canon")


### PR DESCRIPTION
Runs `gradle build` and persists the repl-all.jar artifact. I don't know gradle very well but it seems like you don't generally need to run `gradle test` - `build` is sufficient. LMK if there's other commands you'd like to run for good coverage.

We can also figure out how to add more functionality, such as linting or formatting, in followups.

Demo: https://github.com/dimo414/solarnet/actions/runs/4841273740/jobs/8627399509